### PR TITLE
Update GitHub Actions in gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install 🔧
         run: npm ci
@@ -22,9 +22,9 @@ jobs:
         run: cp ./dist/icalcariam/browser/index.html ./dist/icalcariam/browser/404.html
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           path: dist/icalcariam/browser/
 
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2 #
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated the `gh-pages` workflow by upgrading GitHub Actions to their latest available versions. This ensures compatibility, leverages recent improvements, and possibly resolves known issues.